### PR TITLE
feat: update to mc 1.19

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("fabric-loom") version "0.10.+"
-    id("io.github.juuxel.loom-quiltflower-mini") version "1.2.1"
+    id("fabric-loom") version "0.12.+"
+    id("io.github.juuxel.loom-quiltflower") version "1.7.+"
     `maven-publish`
 }
 
-version = "1.4.0+1.18"
+version = "1.4.0+1.19"
 group = "io.github.ashhhleyyy"
 
 repositories {
@@ -51,15 +51,15 @@ tasks.processResources {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     withSourcesJar()
 }
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
-    options.release.set(16)
+    options.release.set(17)
 }
 
 tasks.jar {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-minecraft = "1.18.1"
-yarn = "1.18.1+build.2"
+minecraft = "1.19"
+yarn = "1.19+build.4"
 
-fabric-loader = "0.12.11"
-fabric-api = "0.44.0+1.18"
+fabric-loader = "0.14.8"
+fabric-api = "0.56.0+1.19"
 
-placeholder-api = "1.1.3+1.17.1"
-more-codecs = "0.2.1+1.18"
+placeholder-api = "2.0.0-beta.4+1.19"
+more-codecs = "0.2.2+1.18"
 
 fabric-permissions = "0.1-SNAPSHOT"
 

--- a/src/main/java/io/github/ashisbored/playerpronouns/PlayerPronouns.java
+++ b/src/main/java/io/github/ashisbored/playerpronouns/PlayerPronouns.java
@@ -1,14 +1,14 @@
 package io.github.ashisbored.playerpronouns;
 
-import eu.pb4.placeholders.PlaceholderAPI;
-import eu.pb4.placeholders.PlaceholderContext;
-import eu.pb4.placeholders.PlaceholderResult;
+import eu.pb4.placeholders.api.PlaceholderContext;
+import eu.pb4.placeholders.api.PlaceholderResult;
+import eu.pb4.placeholders.api.Placeholders;
 import io.github.ashisbored.playerpronouns.command.PronounsCommand;
 import io.github.ashisbored.playerpronouns.data.PronounDatabase;
 import io.github.ashisbored.playerpronouns.data.PronounList;
 import io.github.ashisbored.playerpronouns.data.Pronouns;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -60,23 +60,23 @@ public class PlayerPronouns implements ModInitializer {
         });
 
         //noinspection CodeBlock2Expr
-        CommandRegistrationCallback.EVENT.register((dispatcher, __) -> {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registry, env) -> {
             PronounsCommand.register(dispatcher);
         });
 
-        PlaceholderAPI.register(new Identifier(MOD_ID, "pronouns"), ctx ->
-                PlayerPronouns.fromContext(ctx, true));
+        Placeholders.register(new Identifier(MOD_ID, "pronouns"), (ctx, argument)->
+                PlayerPronouns.fromContext(ctx, argument, true));
 
-        PlaceholderAPI.register(new Identifier(MOD_ID, "raw_pronouns"), ctx ->
-                PlayerPronouns.fromContext(ctx, false));
+        Placeholders.register(new Identifier(MOD_ID, "raw_pronouns"), (ctx, argument)->
+                PlayerPronouns.fromContext(ctx, argument, false));
     }
 
-    private static PlaceholderResult fromContext(PlaceholderContext ctx, boolean formatted) {
+    private static PlaceholderResult fromContext(PlaceholderContext ctx, @Nullable String argument, boolean formatted) {
         if (!ctx.hasPlayer()) {
             return PlaceholderResult.invalid("missing player");
         }
-        String defaultMessage = ctx.hasArgument() ? ctx.getArgument() : config.getDefaultPlaceholder();
-        ServerPlayerEntity player = ctx.getPlayer();
+        String defaultMessage = argument != null ? argument : config.getDefaultPlaceholder();
+        ServerPlayerEntity player = ctx.player();
         if (pronounDatabase == null) {
             return PlaceholderResult.value(defaultMessage);
         }

--- a/src/main/java/io/github/ashisbored/playerpronouns/command/PronounsCommand.java
+++ b/src/main/java/io/github/ashisbored/playerpronouns/command/PronounsCommand.java
@@ -8,7 +8,6 @@ import io.github.ashisbored.playerpronouns.data.Pronouns;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
@@ -28,7 +27,7 @@ public class PronounsCommand {
 
                             Map<String, Text> pronounTexts = PronounList.get().getCalculatedPronounStrings();
                             if (!PlayerPronouns.config.allowCustom() && !pronounTexts.containsKey(pronounsString)) {
-                                ctx.getSource().sendError(new LiteralText("Custom pronouns have been disabled by the server administrator."));
+                                ctx.getSource().sendError(Text.literal("Custom pronouns have been disabled by the server administrator."));
                                 return 0;
                             }
 
@@ -36,13 +35,13 @@ public class PronounsCommand {
                             if (pronounTexts.containsKey(pronounsString)) {
                                 pronouns = new Pronouns(pronounsString, pronounTexts.get(pronounsString));
                             } else {
-                                pronouns = new Pronouns(pronounsString, new LiteralText(pronounsString));
+                                pronouns = new Pronouns(pronounsString, Text.literal(pronounsString));
                             }
 
                             if (!PlayerPronouns.setPronouns(player, pronouns)) {
-                                ctx.getSource().sendError(new LiteralText("Failed to update pronouns, sorry"));
+                                ctx.getSource().sendError(Text.literal("Failed to update pronouns, sorry"));
                             } else {
-                                ctx.getSource().sendFeedback(new LiteralText("Updated your pronouns to ")
+                                ctx.getSource().sendFeedback(Text.literal("Updated your pronouns to ")
                                         .append(pronouns.formatted())
                                         .formatted(Formatting.GREEN), false);
                             }
@@ -53,16 +52,16 @@ public class PronounsCommand {
                         .requires(ctx -> Permissions.check(ctx, "playerpronouns.reload_config", 4))
                         .executes(ctx -> {
                             PlayerPronouns.reloadConfig();
-                            ctx.getSource().sendFeedback(new LiteralText("Reloaded the config!").formatted(Formatting.GREEN), true);
+                            ctx.getSource().sendFeedback(Text.literal("Reloaded the config!").formatted(Formatting.GREEN), true);
                             return Command.SINGLE_SUCCESS;
                         })
                 ).then(literal("unset")
                         .executes(ctx -> {
                             ServerPlayerEntity player = ctx.getSource().getPlayer();
                             if (!PlayerPronouns.setPronouns(player, null)) {
-                                ctx.getSource().sendError(new LiteralText("Failed to update pronouns, sorry"));
+                                ctx.getSource().sendError(Text.literal("Failed to update pronouns, sorry"));
                             } else {
-                                ctx.getSource().sendFeedback(new LiteralText("Cleared your pronouns!")
+                                ctx.getSource().sendFeedback(Text.literal("Cleared your pronouns!")
                                         .formatted(Formatting.GREEN), false);
                             }
                             return Command.SINGLE_SUCCESS;

--- a/src/main/java/io/github/ashisbored/playerpronouns/data/BinaryPronounDatabase.java
+++ b/src/main/java/io/github/ashisbored/playerpronouns/data/BinaryPronounDatabase.java
@@ -2,7 +2,6 @@ package io.github.ashisbored.playerpronouns.data;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +54,7 @@ public class BinaryPronounDatabase {
         Object2ObjectMap<UUID, Pronouns> pronouns = new Object2ObjectOpenHashMap<>();
         Map<String, Text> pronounStrings = PronounList.get().getCalculatedPronounStrings();
         for (var entry : BinaryPronounDatabase.load(path).data.entrySet()) {
-            Text formatted = new LiteralText(entry.getValue());
+            Text formatted = Text.literal(entry.getValue());
             if (pronounStrings.containsKey(entry.getValue())) {
                 formatted = pronounStrings.get(entry.getValue());
             }

--- a/src/main/java/io/github/ashisbored/playerpronouns/data/Pronoun.java
+++ b/src/main/java/io/github/ashisbored/playerpronouns/data/Pronoun.java
@@ -92,7 +92,7 @@ public record Pronoun(
     }
 
     public MutableText toText() {
-        return new LiteralText(this.pronoun).setStyle(this.style);
+        return Text.literal(this.pronoun).setStyle(this.style);
     }
 
     @Override

--- a/src/main/java/io/github/ashisbored/playerpronouns/data/PronounList.java
+++ b/src/main/java/io/github/ashisbored/playerpronouns/data/PronounList.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.github.ashisbored.playerpronouns.Config;
 import io.github.ashisbored.playerpronouns.PlayerPronouns;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -53,9 +52,9 @@ public class PronounList {
                 if (i == j) continue;
                 Pronoun a = combinedPairs.get(i);
                 Pronoun b = combinedPairs.get(j);
-                MutableText combined = new LiteralText("");
+                MutableText combined = Text.literal("");
                 combined.append(a.toText());
-                combined.append(new LiteralText("/"));
+                combined.append(Text.literal("/"));
                 combined.append(b.toText());
                 ret.put(a.pronoun() + "/" + b.pronoun(), combined);
             }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,11 +19,11 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.12.11",
+    "fabricloader": ">=0.14.8",
     "fabric": "*",
-    "minecraft": ">=1.18.1",
-    "more_codecs": ">=0.2.1",
-    "placeholder-api": ">=1.0.1",
+    "minecraft": ">=1.19",
+    "more_codecs": ">=0.2.2",
+    "placeholder-api": ">=2.0.0-beta",
     "fabric-permissions-api-v0": "*"
   }
 }


### PR DESCRIPTION
Updates to Minecraft 1.19

Also updates other deps:
* minecraft: `1.18.1 -> 1.19`
* yarn: `1.18.1+build.2 -> 1.19+build.4`
* fabric loader: `0.12.11 -> 0.14.8`
* fabric api: `0.44.0+1.18 -> 0.56.0+1.19`
* placeholder-api: `1.1.3+1.17.1 -> 2.0.0-beta.4+1.19` (idk if you want to depend on a beta version but the latest stable is for 1.18)
* more-codecs: `0.2.1+1.18 -> 0.2.2+1.18`
* migrates to `fabric-command-api-v2`

Note: currently targeting `1.18` as there isn't an existing `1.19` branch to target.

Closes #4