### PR TITLE
feat: 1.19.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
 }
 
-version = "1.6.0+1.19"
+version = "1.6.0+1.19.3"
 group = "dev.ashhhleyyy"
 
 repositories {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-minecraft = "1.19"
-yarn = "1.19+build.4"
+minecraft = "1.19.3"
+yarn = "1.19.3+build.5"
 
-fabric-loader = "0.14.8"
-fabric-api = "0.56.0+1.19"
+fabric-loader = "0.14.11"
+fabric-api = "0.69.1+1.19.3"
 
-placeholder-api = "2.0.0-beta.7+1.19"
-more-codecs = "0.2.2+1.18"
+placeholder-api = "2.0.0-pre.2+1.19.3"
+more-codecs = "0.3.0+1.19.3"
 
 fabric-permissions = "0.1-SNAPSHOT"
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,10 +19,10 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.14.8",
+    "fabricloader": ">=0.14.11",
     "fabric": "*",
-    "minecraft": ">=1.19",
-    "more_codecs": ">=0.2.2",
+    "minecraft": ">=1.19.3",
+    "more_codecs": ">=0.3.0",
     "placeholder-api": ">=2.0.0-beta",
     "fabric-permissions-api-v0": "*"
   }


### PR DESCRIPTION
For some reason all it took was a dependency update and it was running fine on a 1.19.3 server for me. Thought it would take more. Using the 1.19.2 version on 1.19.3, setting pronouns didn't work (and the placeholder returned default for everyone)